### PR TITLE
replace unmaintained rust-crypto crate by RustCrypto crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,13 @@ version = "0.1.0"
 authors = ["Takeru Ohta <phjgt308@gmail.com>"]
 
 [dependencies]
-trackable = "0.1"
+aes-ctr = "0.6.0"
 handy_async = "0.2"
-rust-crypto = "0.2"
+hmac = "0.10.1"
 num = "0.1"
+sha-1 = "0.9.2"
 splay_tree = "0.2"
+trackable = "0.1"
 
 [dev-dependencies]
 clap = "2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
 #[macro_use]
 extern crate trackable;
-extern crate crypto;
+extern crate aes_ctr;
 extern crate handy_async;
+extern crate hmac;
 extern crate num;
+extern crate sha1;
 extern crate splay_tree;
 
 pub use error::{Error, ErrorKind};


### PR DESCRIPTION
using the `RustCrypto` crates instead of the `rust-crypto` crate as mentioned in the `RustCrypto GitHub Org` Section of [this Advisory](https://rustsec.org/advisories/RUSTSEC-2016-0005)  