### PR TITLE
replace unmaintained rust-crypto crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,15 @@ default = []
 rfc5764-openssl = ["openssl", "tokio-openssl", "tokio-util/compat"]
 
 [dependencies]
-trackable = "0.1"
-handy_async = "0.2"
-rust-crypto = "0.2"
-num = "0.1"
-fixedbitset = "0.1"
-futures = "0.3"
+aes-ctr = "0.6.0"
 async-trait = "0.1"
+futures = "0.3"
+handy_async = "0.2"
+hmac = "0.10.1"
+num = "0.1"
+sha-1 = "0.9.2"
+trackable = "0.1"
+fixedbitset = "0.1"
 
 openssl = { version = "0.10", optional = true }
 tokio-openssl = { version = "0.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,13 @@ rfc5764-openssl = ["openssl", "tokio-openssl", "tokio-util/compat"]
 [dependencies]
 aes-ctr = "0.6.0"
 async-trait = "0.1"
+fixedbitset = "0.1"
 futures = "0.3"
 handy_async = "0.2"
 hmac = "0.10.1"
 num = "0.1"
 sha-1 = "0.9.2"
 trackable = "0.1"
-fixedbitset = "0.1"
 
 openssl = { version = "0.10", optional = true }
 tokio-openssl = { version = "0.4", optional = true }


### PR DESCRIPTION
using the `RustCrypto` crates instead of the `rust-crypto` crate as
mentioned in the `RustCrypto GitHub Org` Section of [this
Advisory](https://rustsec.org/advisories/RUSTSEC-2016-0005)