### PR TITLE
Please the compiler by suppling type hints.

### DIFF
--- a/src/rfc3711.rs
+++ b/src/rfc3711.rs
@@ -470,11 +470,12 @@ where
         ssrc: u32,
         index: P::PacketIndex,
     ) {
-        let iv = BigUint::from_bytes_be(&context.session_salt_key) << 16;
-        let iv = iv ^ (BigUint::from(ssrc) << 64);
-        let iv = iv ^ (index.into() << 16);
-        let iv = iv ^ (BigUint::from(1_u8) << (context.session_encr_key.len() * 8));
-        let iv = &iv.to_bytes_be()[1..context.session_encr_key.len() + 1];
+        let iv: BigUint = BigUint::from_bytes_be(&context.session_salt_key) << 16;
+        let iv: BigUint = iv ^ (BigUint::from(ssrc) << 64);
+        let index_biguint: BigUint = index.into();
+        let iv: BigUint = iv ^ (index_biguint << 16);
+        let iv: BigUint = iv ^ (BigUint::from(1_u8) << (context.session_encr_key.len() * 8));
+        let iv: &[u8] = &iv.to_bytes_be()[1..context.session_encr_key.len() + 1];
 
         let mut ctr =
             aes_ctr::Aes128Ctr::new_var(&context.session_encr_key, iv).expect("Correct Key Length");
@@ -504,11 +505,12 @@ where
         ssrc: u32,
         index: P::PacketIndex,
     ) {
-        let iv = BigUint::from_bytes_be(&context.session_salt_key) << 16;
-        let iv = iv ^ (BigUint::from(ssrc) << 64);
-        let iv = iv ^ (index.into() << 16);
-        let iv = iv ^ (BigUint::from(1_u8) << (context.session_encr_key.len() * 8));
-        let iv = &iv.to_bytes_be()[1..context.session_encr_key.len() + 1];
+        let iv: BigUint = BigUint::from_bytes_be(&context.session_salt_key) << 16;
+        let iv: BigUint = iv ^ (BigUint::from(ssrc) << 64);
+        let index_biguint: BigUint = index.into();
+        let iv: BigUint = iv ^ (index_biguint << 16);
+        let iv: BigUint = iv ^ (BigUint::from(1_u8) << (context.session_encr_key.len() * 8));
+        let iv: &[u8] = &iv.to_bytes_be()[1..context.session_encr_key.len() + 1];
 
         let mut ctr =
             aes_ctr::Aes128Ctr::new_var(&context.session_encr_key, iv).expect("Correct Key Length");


### PR DESCRIPTION
First of all: Rust is not a language I have a good understanding of, although I do have some background in C++ and its memory management. Please request changes when I did something ugly in Rust, because I most certainly did.

I accidentally made an issue on the project this project was forked on about this (https://github.com/sile/rtp/issues/2), but in short, I noticed when compiling this project, I got the following error on rustc 1.49:
```
error[E0282]: type annotations needed
   --> /build/mumblewebproxy-vendor.tar.gz/rtp/src/rfc3711.rs:476:19
    |
475 |         let iv = iv ^ (BigUint::from(1_u8) << (context.session_encr_key.len() * 8));
    |             -- consider giving `iv` a type
476 |         let iv = &iv.to_bytes_be()[1..context.session_encr_key.len() + 1];
    |                   ^^ cannot infer type
    |
    = note: type must be known at this point

error[E0282]: type annotations needed
   --> /build/mumblewebproxy-vendor.tar.gz/rtp/src/rfc3711.rs:512:19
    |
511 |         let iv = iv ^ (BigUint::from(1_u8) << (context.session_encr_key.len() * 8));
    |             -- consider giving `iv` a type
512 |         let iv = &iv.to_bytes_be()[1..context.session_encr_key.len() + 1];
    |                   ^^ cannot infer type
    |
    = note: type must be known at this point

error: aborting due to 2 previous errors
```

This pull request fixes this compile error. I've run the unit tests as well (with `cargo test`) and they still seem to work.